### PR TITLE
Allow users to use standard MongoDB connection strings

### DIFF
--- a/UserStore.cs
+++ b/UserStore.cs
@@ -27,6 +27,12 @@ namespace MongoDB.AspNet.Identity
             MongoServer server = new MongoClient(settings).GetServer();
             db = server.GetDatabase(conString.DatabaseName);
         }
+        
+        public UserStore(string connectionString, string dbName)
+        {
+            var client = new MongoClient(ConfigurationManager.ConnectionStrings[connectionString].ConnectionString);
+            db = client.GetServer().GetDatabase(dbName);
+        }
 
         public Task CreateAsync(TUser user)
         {


### PR DESCRIPTION
I am proposing the following change so that anyone who uses this can use the Url Connection String format.  Also being able to specify the dbName will allow the user to authenticate to one database and use another to store user information.
